### PR TITLE
fix import type syntax for deno v1.4.4

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@
  * https://marton.lederer.hu
  */
 
-import { Prefix } from './lib/prefix/Prefix.ts'
+import type { Prefix } from './lib/prefix/Prefix.ts'
 
 /*
 *


### PR DESCRIPTION
The syntax has changed when importing types that are not used as variables in deno v1.4.4.
You must use `import type` instead of `import` if you don't want this error to be raised : 

```
error: TS1371 [ERROR]: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
import { Prefix } from './lib/prefix/Prefix.ts'
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
at https://deno.land/x/houston@1.0.0/src/types.ts:9:1
```